### PR TITLE
feat: add context menu

### DIFF
--- a/Sweechat.xcodeproj/project.pbxproj
+++ b/Sweechat.xcodeproj/project.pbxproj
@@ -755,7 +755,6 @@
 			isa = PBXGroup;
 			children = (
 				3EC8C1912617322D008672C4 /* Extension */,
-				77C5D09026103728005D5504 /* Message */,
 				77C5D08F2610371C005D5504 /* User */,
 				77C5D07926102F51005D5504 /* Module */,
 				27885832261053A00058ADB2 /* Home */,
@@ -983,13 +982,6 @@
 				27BD8F2E2619730A00B0F7D7 /* MemberItemView.swift */,
 			);
 			path = User;
-			sourceTree = "<group>";
-		};
-		77C5D09026103728005D5504 /* Message */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Message;
 			sourceTree = "<group>";
 		};
 		77F4F14E2618A707003CD601 /* Fonts */ = {

--- a/Sweechat/Constants/DatabaseConstant.swift
+++ b/Sweechat/Constants/DatabaseConstant.swift
@@ -10,7 +10,7 @@ import Foundation
 struct DatabaseConstant {
     struct Collection {
         static let environmentCollection = "environment"
-        static let dev = "module-permissions"
+        static let dev = "message-edit-delete"
         // Change environmentDocument as needed when working on features
         // involving a schema change
         static let environmentDocument = dev

--- a/Sweechat/Views/ChatRoom/Message/MessageView.swift
+++ b/Sweechat/Views/ChatRoom/Message/MessageView.swift
@@ -33,6 +33,25 @@ struct MessageView: View {
             .foregroundColor(viewModel.foregroundColor)
             .background(viewModel.backgroundColor)
             .cornerRadius(10)
+            .contentShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .contextMenu {
+                Button {
+                    print("Replied")
+                } label: {
+                    Label("Reply", systemImage: "arrowshape.turn.up.left")
+                }
+                Button {
+                    print("Edited")
+                } label: {
+                    Label("Edit", systemImage: "square.and.pencil")
+                }
+                Divider()
+                Button {
+                    print("Deleted")
+                } label: {
+                    Label("Delete", systemImage: "trash")
+                }
+            }
             if !viewModel.isRightAlign { Spacer() }
         }
         .frame(maxWidth: .infinity)


### PR DESCRIPTION
Added the context menu:

<img width="485" alt="Screenshot 2021-04-08 at 12 58 50 AM" src="https://user-images.githubusercontent.com/37838247/113905424-b7bff080-9805-11eb-92b7-e09988793c8b.png">

The context menu code is currently in the MessageView. This means that the Reply functionality has to be shifted to Message if we want to use the context menu. Putting the context menu in the MessageScrollView will mess up the message alignment as it takes reference to the entire HStack around the message and centres the message horizontally. There is also a SwiftUI bug which makes it such that we can't change the colours of context menu items. Made this PR to discuss the general direction going forward, i.e. the feasibility of having Reply, Edit, Delete be part of the MessageView/ViewModel.