### PR TITLE
fix: fix local copy of message likers not updating when liked in real-time

### DIFF
--- a/Sweechat/Models/Message/Message.swift
+++ b/Sweechat/Models/Message/Message.swift
@@ -57,9 +57,8 @@ class Message: ObservableObject {
     }
 
     func update(message: Message) {
-        if self.content != message.content {
-            self.content = message.content
-        }
+        self.content = message.content
+        self.likers = message.likers
     }
 
     func toggleLike(of userId: UserId) {


### PR DESCRIPTION
By not placing `self.likers = message.likers`, when you are logged in and someone changes the database, your local copy of `likers` will not be updated. Thus when you click on 'like' again, it will send a non=updated one