### PR TITLE
fix: image loading

### DIFF
--- a/Sweechat/Utilities/ImageDataViewModel.swift
+++ b/Sweechat/Utilities/ImageDataViewModel.swift
@@ -27,6 +27,9 @@ class ImageDataViewModel: ObservableObject {
     }
 
     func updateUrl(url: String) {
+        if url == self.urlString {
+            return
+        }
         self.urlString = url
         self.state = .loading
         fetchData()


### PR DESCRIPTION
When an image message is liked, the image will not reload. This logic has already been applied to `VideoMessageViewModel`