### PR TITLE
fix: bad access to forum due to non-existent function

### DIFF
--- a/Sweechat/Views/ChatRoom/ForumChatRoomView.swift
+++ b/Sweechat/Views/ChatRoom/ForumChatRoomView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ForumChatRoomView: View {
     @ObservedObject var viewModel: ForumChatRoomViewModel
     @State var parentPreviewMetadata: ParentPreviewMetadata?
+    @Binding var isNavigationBarHidden: Bool
 
     var body: some View {
         VStack {
@@ -11,6 +12,10 @@ struct ForumChatRoomView: View {
                                 isShowingParentPreview: false,
                                 allowSendMedia: false,
                                 parentPreviewMetadata: $parentPreviewMetadata)
-        }.navigationTitle(viewModel.text)
+        }
+        .onAppear {
+            isNavigationBarHidden = false
+        }
+        .navigationTitle(viewModel.text)
     }
 }

--- a/Sweechat/Views/ChatRoom/Message/ChatRoomViewFactory.swift
+++ b/Sweechat/Views/ChatRoom/Message/ChatRoomViewFactory.swift
@@ -34,4 +34,9 @@ struct ChatRoomViewFactory {
             return AnyView(ChatRoomView(viewModel: viewModel, isNavigationBarHidden: isNavigationBarHidden))
         }
     }
+
+    static func makeView(viewModel: ForumChatRoomViewModel, isNavigationBarHidden: Binding<Bool>) -> some View {
+        ForumChatRoomView(viewModel: viewModel,
+                          isNavigationBarHidden: isNavigationBarHidden)
+    }
 }


### PR DESCRIPTION
Without the `makeView` function that accepts the `ForumViewModel`, during runtime it would be unable to access the function.

During compile-time, it still typechecks because it seems to bind to the function that calls it (which accepts the more general `ChatRoomViewModel`